### PR TITLE
implement otp rate limiter middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The `OtpManager` class is responsible for sending and verifying one-time passwor
 * Send OTPs via mobile numbers
 * Resend OTPs with built-in throttling
 * Verify OTP codes
+* Track OTP requests for security
 * Supports multiple types of OTPs (e.g., login, reset password)
 
 ## Installation
@@ -137,6 +138,23 @@ php artisan config:clear
 ```
 Then, you can adjust the waiting_time, code_min, and code_max in the `config/otp.php`
 
+## Middleware Protection
+The OtpManager package includes built-in middleware (OtpRateLimiter) to protect your application routes from excessive OTP requests. This helps prevent potential abuse.
+
+### To apply the middleware:
+
+**Register the middleware:** Add `\Salehhashemi\OtpManager\Middleware\OtpRateLimiter::class` to the `middlewareAliases` array in your `app\Http\Kernel.php` file.
+
+**Assign the middleware to routes:** You can apply it to specific routes or route groups where you want to implement rate limiting.
+
+Example:
+
+```php
+Route::middleware('otp-rate-limiter')->group(function () {
+// Routes that require OTP rate limiting go here
+});
+```
+
 ## Custom Mobile Number Validation
 The package comes with a default mobile number validator, but you can easily use your own. 
 
@@ -165,7 +183,7 @@ Next, open your OTP configuration file and update the `mobile_validation_class` 
 * `\InvalidArgumentException` will be thrown if the mobile number is empty.
 * `\Exception` will be thrown for general exceptions, like OTP generation failures.
 * `\Illuminate\Validation\ValidationException` will be thrown for throttle restrictions.
-
+* `\Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException` will be thrown for throttled requests.
 
 ## Docker Setup
 This project uses Docker for local development and testing. Make sure you have Docker and Docker Compose installed on your system before proceeding.

--- a/config/otp.php
+++ b/config/otp.php
@@ -39,4 +39,18 @@ return [
     |
     */
     'mobile_validation_class' => DefaultMobileValidator::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate Limiting Configurations
+    |--------------------------------------------------------------------------
+    |
+    | These options define the rate limiting configurations for the OTP
+    | manager. Adjust these values as per your security requirements.
+    |
+    */
+    'rate_limiting' => [
+        'max_attempts' => 5,
+        'decay_minutes' => 1,
+    ],
 ];

--- a/src/Middleware/OtpRateLimiter.php
+++ b/src/Middleware/OtpRateLimiter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Salehhashemi\OtpManager\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+class OtpRateLimiter
+{
+    public function handle(Request $request, Closure $next, ?string $key = null): mixed
+    {
+        if ($key === null) {
+            $key = $request->ip().'|'.Str::slug($request->userAgent() ?? 'default', '|');
+        }
+
+        $maxAttempts = config('otp.rate_limiting.max_attempts', 5);
+        $decaySeconds = config('otp.rate_limiting.decay_minutes', 1) * 60;
+
+        if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
+            $seconds = RateLimiter::availableIn($key);
+
+            throw new TooManyRequestsHttpException(
+                $seconds,
+                "Too Many Attempts. Please try again in $seconds seconds."
+            );
+        }
+
+        RateLimiter::hit($key, $decaySeconds);
+
+        return $next($request);
+    }
+}

--- a/tests/OtpRateLimiterTest.php
+++ b/tests/OtpRateLimiterTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Salehhashemi\OtpManager\Tests;
+
+use Illuminate\Http\Request;
+use Salehhashemi\ConfigurableCache\ConfigurableCacheServiceProvider;
+use Salehhashemi\OtpManager\Middleware\OtpRateLimiter;
+use Salehhashemi\OtpManager\OtpManagerServiceProvider;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+class OtpRateLimiterTest extends BaseTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [OtpManagerServiceProvider::class, ConfigurableCacheServiceProvider::class];
+    }
+
+    public function test_middleware_blocks_requests_above_limit()
+    {
+        config(['otp.rate_limiting.max_attempts' => 3]);
+
+        $request = Request::create('/', 'GET', ['REMOTE_ADDR' => '127.0.0.1']);
+
+        $middleware = new OtpRateLimiter();
+
+        $this->expectException(TooManyRequestsHttpException::class);
+
+        // Trigger middleware multiple times to exceed the limit
+        for ($i = 0; $i < 5; $i++) {
+            $response = $middleware->handle($request, function () {
+            });
+        }
+    }
+
+    public function test_middleware_does_not_block_requests_below_limit()
+    {
+        config(['otp.rate_limiting.max_attempts' => 3]);
+
+        $request = Request::create('/', 'GET', ['REMOTE_ADDR' => '127.0.0.1']);
+
+        $middleware = new OtpRateLimiter();
+
+        for ($i = 0; $i < 2; $i++) {
+            $response = $middleware->handle($request, function () {
+                return response('Passed', 200);
+            });
+        }
+
+        // Assert that the last response has the correct status code
+        $this->assertEquals(200, $response->status());
+    }
+}


### PR DESCRIPTION
Type: New Feature
Description: Added rate limiting configurations to the 'otp.php' config file. This includes 'max_attempts' and 'decay_minutes' setting, which allows you to customize the rate at which OTP requests are allowed.

Type: New Feature
Description: Introduced a new middleware 'OtpRateLimiter.php'. This middleware handles rate limiting for OTP requests based on the settings defined in the 'otp.php' config file. If a user exceeds the maximum number of OTP attempts, they will receive a JSON response indicating that they have made too many requests and should try again later.

Type: Test
Description: Added a new test file 'OtpRateLimiterTest.php'. This file contains two tests to ensure the new OtpRateLimiter middleware works as expected. The first test 'test_middleware_blocks_requests_above_limit' checks if the middleware correctly blocks OTP requests that exceed the maximum limit. The second test 'test_middleware_does_not_block_requests_below_limit' checks if the middleware allows OTP requests that are below the maximum limit.