### PR TITLE
add prefix for otp rate limiter middleware and encrypting the key

### DIFF
--- a/src/Middleware/OtpRateLimiter.php
+++ b/src/Middleware/OtpRateLimiter.php
@@ -13,7 +13,7 @@ class OtpRateLimiter
     public function handle(Request $request, Closure $next, ?string $key = null): mixed
     {
         if ($key === null) {
-            $key = $request->ip().'|'.Str::slug($request->userAgent() ?? 'default', '|');
+            $key = 'otp-rate-limit:'.$request->ip().'|'.Str::slug($request->userAgent() ?? 'default', '|');
         }
 
         $maxAttempts = config('otp.rate_limiting.max_attempts', 5);


### PR DESCRIPTION
Updated the key used for rate limiting in the OtpRateLimiter middleware. The key now includes a prefix 'otp-rate-limit:', providing better context.