### PR TITLE
auto-delete the OTP code after successful verification

### DIFF
--- a/src/OtpManager.php
+++ b/src/OtpManager.php
@@ -128,6 +128,9 @@ class OtpManager
 
         $this->resetSendAttempts($mobile); // Reset on successful verification
 
+        // Auto-delete the OTP code after successful verification
+        $this->deleteVerifyCode($mobile, $type);
+
         return true;
     }
 


### PR DESCRIPTION
Added a feature to automatically delete the One-Time Password (OTP) code from the system after successful verification. This will help maintain the cleanliness of the data by removing unneeded OTP codes and possibly improve system performance.