### PR TITLE
Incorrect OTP retry time calculation

### DIFF
--- a/src/OtpManager.php
+++ b/src/OtpManager.php
@@ -87,7 +87,7 @@ class OtpManager
             return $this->send($mobile, $type);
         }
 
-        $remainingTime = $retryAfter->diffInSeconds(Carbon::now());
+        $remainingTime = (int) Carbon::now()->diffInSeconds($retryAfter);
 
         throw ValidationException::withMessages([
             'otp' => [


### PR DESCRIPTION
Ensure `remainingTime` is a positive Integer in `OtpManager`.